### PR TITLE
Add ability to choose the table class on html output and to put a counter on it.

### DIFF
--- a/app/views/dossier/reports/show.html.haml
+++ b/app/views/dossier/reports/show.html.haml
@@ -1,13 +1,18 @@
 %h1= report.class.name.titleize
 
-%table
+-klass = params[:options].try(:values_at,:table_class)
+%table{class: klass}
   %thead
     %tr
+      -if params[:options].try(:[],:count)
+        %th
       - report.results.headers.each do |header|
         %th= Dossier::Formatter.titleize(header)
   %tbody
-    - report.results.body.each do |row|
+    - report.results.body.each_with_index do |row,i|
       %tr
+        -if params[:options] && params[:options][:count]
+          %td= i+1
         - row.each do |value|
           %td= value
 

--- a/spec/fixtures/reports/employee_with_parameters.html
+++ b/spec/fixtures/reports/employee_with_parameters.html
@@ -9,9 +9,10 @@
 <body>
 
 <h1>Employee Report</h1>
-<table>
+<table class='table'>
 <thead>
 <tr>
+<th></th>
 <th>Id</th>
 <th>Name</th>
 <th>Division</th>
@@ -22,6 +23,7 @@
 </thead>
 <tbody>
 <tr>
+<td>1</td>
 <td>2</td>
 <td>Employee Jimmy Jackalope, Jr.</td>
 <td>Tedious Toiling</td>
@@ -31,7 +33,7 @@
 </tr>
 </tbody>
 </table>
-<a href="/reports/employee.csv?options%5Bdivisions%5D%5B%5D=Tedious+Toiling&amp;options%5Bnames%5D%5B%5D=Jimmy+Jackalope&amp;options%5Bnames%5D%5B%5D=Moustafa+McMann&amp;options%5Border%5D=desc&amp;options%5Bsalary%5D=true" class="download-csv">Download CSV</a>
+<a href="/reports/employee.csv?options%5Bcount%5D=true&amp;options%5Bdivisions%5D%5B%5D=Tedious+Toiling&amp;options%5Bnames%5D%5B%5D=Jimmy+Jackalope&amp;options%5Bnames%5D%5B%5D=Moustafa+McMann&amp;options%5Border%5D=desc&amp;options%5Bsalary%5D=true&amp;options%5Btable_class%5D=table" class="download-csv">Download CSV</a>
 
 
 </body>

--- a/spec/requests/employee_spec.rb
+++ b/spec/requests/employee_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe "employee report" do
+  def open(filename)
+    File.read("spec/fixtures/reports/#{filename}")
+  end
 
   describe "rendering HTML" do
 
@@ -8,7 +11,7 @@ describe "employee report" do
 
       it "uses the custom view" do
         get '/reports/employee_with_custom_view'
-        expect(response.body).to eq(File.read('spec/fixtures/reports/employee_with_custom_view.html'))
+        expect(response.body).to eq open('employee_with_custom_view.html')
       end
 
     end
@@ -17,23 +20,25 @@ describe "employee report" do
 
       it "creates an HTML report using its standard 'show' view" do
         get '/reports/employee'
-        expect(response.body).to eq(File.read('spec/fixtures/reports/employee.html'))
+        expect(response.body).to eq open('employee.html')
       end
 
       it "uses any options provided" do
         get '/reports/employee', options: {
           salary: true, order: 'desc', 
           names: ['Jimmy Jackalope', 'Moustafa McMann'],
-          divisions: ['Tedious Toiling']
+          divisions: ['Tedious Toiling'],
+          count: true,
+          table_class: 'table'
         }
-        expect(response.body).to eq(File.read('spec/fixtures/reports/employee_with_parameters.html'))
+        expect(response.body).to eq open('employee_with_parameters.html')
       end
 
       it "moves the specified number of rows into the footer" do
         get '/reports/employee', options: {
           footer: 1
         }
-        expect(response.body).to eq(File.read('spec/fixtures/reports/employee_with_footer.html'))
+        expect(response.body).to eq open('employee_with_footer.html')
       end
 
     end
@@ -44,7 +49,7 @@ describe "employee report" do
 
     it "creates a standard CSV report" do
       get '/reports/employee.csv'
-      expect(response.body).to eq(File.read('spec/fixtures/reports/employee.csv'))
+      expect(response.body).to eq open('employee.csv')
     end
 
   end
@@ -53,7 +58,7 @@ describe "employee report" do
 
     it "creates a standard XLS report" do
       get '/reports/employee.xls'
-      expect(response.body).to eq(File.read('spec/fixtures/reports/employee.xls'))
+      expect(response.body).to eq open('employee.xls')
     end
 
   end


### PR DESCRIPTION
I found this two features very useful if you work with big tables, as a left counter helps it a lot! Also with the custom class table one can easily use bootstrap's goodies (class='table').

It would be better implement the counter on a more lower level, so every outputter would benefit for it, but for now I think it works pretty well.
