### PR TITLE
Heroku compatability

### DIFF
--- a/lib/dossier/configuration.rb
+++ b/lib/dossier/configuration.rb
@@ -13,7 +13,7 @@ module Dossier
     private
 
     def setup_client!
-      @connection_options = YAML.load_file(@config_path)[Rails.env].symbolize_keys
+      @connection_options = YAML.load(ERB.new(File.read(@config_path)).result)[Rails.env].symbolize_keys
       @client = Dossier::Client.new(@connection_options)
 
     rescue Errno::ENOENT => e


### PR DESCRIPTION
Heroku uses erb in the database.yml file they create, this leads to an error similar to:

'(/app/config/dossier.yml): mapping values are not allowed in this context at line 22 column 13'

This fixes that and still works with files that don't have ERB.
