### PR TITLE
update readme to show where report examples are

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ end
 
 ## Advanced Usage
 
-To see a report with all the bells and whistles, check out `spec/support/reports/employee_report.rb` or other reports in `spec/support/reports`.
+To see a report with all the bells and whistles, check out `spec/dummy/app/reports/employee_report.rb` or other reports in `spec/dummy/app/reports`.
 
 ## Compatibility
 


### PR DESCRIPTION
`spec/support/reports` doesn't exist anymore, so updating the readme.
