### PR TITLE
Modify Dossier::ConnectionUrl to work with arbitrary query string params

### DIFF
--- a/spec/dossier/connection_url_spec.rb
+++ b/spec/dossier/connection_url_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Dossier::ConnectionUrl do
 
-  let(:database_url) { "mysql2://root:password@127.0.0.1/myapp_development?encoding=utf8" }   
-  
   it "parses the url provided into a hash" do
+    database_url = "mysql2://root:password@127.0.0.1/myapp_development?encoding=utf8"
+
     connection_options = described_class.new(database_url).to_hash
-    expected_options = { adapter: "mysql2",   database: "myapp_development",user:"root",
+    expected_options = { adapter: "mysql2",   database: "myapp_development", username:"root",
                          password:"password", encoding:"utf8", host: "127.0.0.1"}
     expect(connection_options).to eq(expected_options)
   end
@@ -18,6 +18,28 @@ describe Dossier::ConnectionUrl do
     connection_options = described_class.new.to_hash
     expect(connection_options).to eq(expected_options)
     ENV["DATABASE_URL"] = old_db_url
+  end
+
+  it "translates postgres" do
+    database_url  = "postgres://user:secret@localhost/mydatabase"
+    connection_options = described_class.new(database_url).to_hash
+
+    expect(connection_options[:adapter]).to eq("postgresql")
+  end
+
+  it "supports additional options" do
+    database_url  = "postgresql://user:secret@remotehost.example.org:3133/mydatabase?encoding=utf8&random_key=blah"
+    connection_options = described_class.new(database_url).to_hash
+
+    expect(connection_options[:encoding]).to eq("utf8")
+    expect(connection_options[:random_key]).to eq("blah")
+    expect(connection_options[:port]).to eq(3133)
+  end
+
+  it "drops empty values" do
+    database_url  = "postgresql://localhost/mydatabase"
+    connection_options = described_class.new(database_url).to_hash
+    expect(connection_options.slice(:username, :password, :port)).to be_empty
   end
 
 end


### PR DESCRIPTION
Useful for connecting in environment where database connection is specified by url (e.g. Heroku) and the db requires additional configuration, say `ssl_ca` for [Amazon RDS](https://devcenter.heroku.com/articles/amazon_rds)

This also changes the `:user` key to `:username` returned from the connection url hash which I believe to be the more typical key.
