### PR TITLE
Give output files sortable date & time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Dossier does its best to use [semantic versioning](http://semver.org).
 - headers will now be formatted without calling `format_header` in the view, that will be called when accessing them (I'm not sure if this may cause backwards incompatible changes with custom views.  I don't *think* so.
 - introduced `format_column(column, value)` as a default formatter that can be implemented as a fall back if a specific format method does not exist
 - Add license to gemspec, thanks to notice from [Benjamin Fleischer](https://github.com/bf4) - see [his blog post](http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/)
+- Output files now have a sortable date/time stamp by default. Eg, "foo-report_2014-10-02_09-12-24-EDT.csv". This can still be customized by defining a report class's `filename` method.
 
 ## v2.8.0
 - Support namespaces for report names (`cats/are/super_fun` => `Cats::Are::SuperRunReport`

--- a/lib/dossier/report.rb
+++ b/lib/dossier/report.rb
@@ -21,7 +21,7 @@ module Dossier
     end
 
     def self.filename
-      "#{report_name.parameterize}-report_#{Time.now.strftime('%m-%d-%Y_%H-%M-%S')}"
+      "#{report_name.parameterize}-report_#{Time.now.strftime('%Y-%m-%d_%H-%M-%S-%Z')}"
     end
     
     def initialize(options = {})


### PR DESCRIPTION
Eg: “foo-report_2014-10-02_09-12-24-EDT.csv”.
Files named like this can be sorted by name and
will end up in chronological order. Year-month-day
is also a more international date format.
